### PR TITLE
Explicitly encode rendered Jinja templates to UTF8

### DIFF
--- a/bsdploy/bootstrap_utils.py
+++ b/bsdploy/bootstrap_utils.py
@@ -76,7 +76,8 @@ class BootstrapFile(object):
 
     def read(self, context):
         if self.use_jinja:
-            return self.template_from_file(dirname(self.local), self.local, context)
+            result = self.template_from_file(dirname(self.local), self.local, context)
+            return result.encode('utf-8')
         else:
             return open(self.local, 'r')
 


### PR DESCRIPTION
IIRC this fixes the bug encountered with certain Pythons during the tutorial.
