### PR TITLE
Fix interface naming

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -54,7 +54,7 @@ Inside it create a file named ``ploy.conf`` with the following contents::
     [vb-hostonlyif:vboxnet0]
     ip = 192.168.56.1
 
-    [vb-dhcpserver:vboxnet0]
+    [vb-dhcpserver:vboxnet1]
     ip = 192.168.56.2
     netmask = 255.255.255.0
     lowerip = 192.168.56.100


### PR DESCRIPTION
Without this change, virtualbox refused to launch the VM:

INFO: Adding default 'sata' controller.
INFO: Starting instance 'vb-instance:ploy-demo'
ERROR: VBoxManage: error: Nonexistent host networking interface, name '' (VERR_INTERNAL_ERROR)
VBoxManage: error: Details: code NS_ERROR_FAILURE (0x80004005), component Console, interface IConsole

ERROR: Failed to start VM 'ploy-demo':
Command 'VBoxManage startvm ploy-demo' returned non-zero exit status 0
