### PR TITLE
Allow interfaces to be configured it ways other than with DHCP.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@
 - [feature] files copied during bootstrap can be encrypted using the ``ploy vault`` commands. This is useful for the private ssh host keys in ``bootstrap-files``.
 - [fix] fixed setting of virtualbox defaults, so they can be properly overwritten
 - [feature] added new variables: ploy_jail_host_cloned_interfaces/ploy_jail_host_default_jail_interface to give more flexiblity around network interface setup
+- [feature] added new variable: ploy_jail_host_interface_config to allow interfaces to be arbitrarily configured with ifconfig
 
 
 2.0.0 - 2015-03-05

--- a/bsdploy/roles/jails_host/defaults/main.yml
+++ b/bsdploy/roles/jails_host/defaults/main.yml
@@ -29,6 +29,5 @@ ploy_jail_host_cloned_interfaces: lo1
 ploy_jail_host_default_jail_interface: lo1
 ploy_jail_host_interface_config: []
 #ploy_jail_host_interface_config:
-#  - interfaces:
-#    - interface: em0
-#      config: inet 192.168.1.2/24
+#  - interface: em0
+#    config: inet 192.168.1.2/24

--- a/bsdploy/roles/jails_host/defaults/main.yml
+++ b/bsdploy/roles/jails_host/defaults/main.yml
@@ -27,3 +27,8 @@ ploy_root_user_name: "{{ploy_user | default('root')}}"
 ploy_root_home_path: "{{ '/' if ploy_root_user_name == 'root' else '/usr/home/' }}{{ploy_root_user_name}}"
 ploy_jail_host_cloned_interfaces: lo1
 ploy_jail_host_default_jail_interface: lo1
+ploy_jail_host_interface_config: []
+#ploy_jail_host_interface_config:
+#  - interfaces:
+#    - interface: em0
+#      config: inet 192.168.1.2/24

--- a/bsdploy/roles/jails_host/tasks/main.yml
+++ b/bsdploy/roles/jails_host/tasks/main.yml
@@ -16,6 +16,13 @@
     value: "{{ ploy_jail_host_cloned_interfaces }}"
   notify: restart network
 
+- name: Configure interfaces
+  sysrc:
+    name: ifconfig_{{ item.interface }}
+    value: "{{ item.config }}"
+  with_items: ploy_jail_host_interface_config
+  notify: restart network
+
 - meta: flush_handlers
 
 # The sysctl module in ansible adds spaces around the equal sign in

--- a/bsdploy/tests/test_roles.py
+++ b/bsdploy/tests/test_roles.py
@@ -68,6 +68,7 @@ def test_roles(ctrl, monkeypatch):
         'Reload pf.conf',
         'Enable gateway in rc.conf',
         'Setup cloned interfaces',
+        'Configure interfaces',
         'Enable security.jail.allow_raw_sockets',
         'Enable security.jail.sysvipc_allowed',
         'Ensure helper packages are installed',


### PR DESCRIPTION
It seems likely that others will want to apply explicit configuration to interfaces, other than just DHCP. This patch allow that by defining a host variable that allow arbitrary interface configuration:

e.g:

    ploy_jail_host_interface_config:
        - interface: em0
          config: inet 192.168.1.2/24
        - interface: vlan1
          config: inet 192.168.10.250/24 vlan 20 vlandev em0