### PR TITLE
Updated main.yml to use proxy for helper packages.

### DIFF
--- a/bsdploy/roles/jails_host/tasks/main.yml
+++ b/bsdploy/roles/jails_host/tasks/main.yml
@@ -35,10 +35,20 @@
   notify: reload sysctl
   tags: sysctl
 
+- name: Ensure helper packages are installed (using http proxy)
+  pkgng: name={{ item }} state=present
+  with_items:
+  - ezjail
+  when: ploy_http_proxy is defined
+  environment:
+   http_proxy: "{{ploy_http_proxy}}"
+   https_proxy: "{{ploy_http_proxy}}"
+   
 - name: Ensure helper packages are installed
   pkgng: name={{ item }} state=present
   with_items:
   - ezjail
+  when: ploy_http_proxy is not defined
 
 - name: Set default jail interface
   sysrc:

--- a/bsdploy/tests/test_roles.py
+++ b/bsdploy/tests/test_roles.py
@@ -70,6 +70,7 @@ def test_roles(ctrl, monkeypatch):
         'Setup cloned interfaces',
         'Enable security.jail.allow_raw_sockets',
         'Enable security.jail.sysvipc_allowed',
+        'Ensure helper packages are installed (using http proxy)',
         'Ensure helper packages are installed',
         'Set default jail interface',
         'Set default jail parameters',


### PR DESCRIPTION
Modified the task for installing helper packages to use proxy variable http_proxy set in ploy.conf.
This ensures that the task won't fail if http/https proxy is to be used.