### PR TITLE
Add support for DigitalOcean's Fbsd11 release

### DIFF
--- a/bsdploy/bootstrap_utils.py
+++ b/bsdploy/bootstrap_utils.py
@@ -322,6 +322,11 @@ class BootstrapUtils:
             return run('mount')
 
     @lazy
+    def os_release(self):
+        with settings(quiet()):
+            return run('uname -r')
+
+    @lazy
     def sysctl_devices(self):
         with settings(quiet()):
             return run('sysctl -n kern.disks').strip().split()


### PR DESCRIPTION
This addresses #101, and extends our Digital Ocean Fabfile to support
Digital Ocean's FreeBSD11 release.  Cloud-init is mostly invisible here,
and the rc.conf is already good to go. The only new thing is that the
root account is locked, so we unlock it.