### PR TITLE
update bootstrapping for Digital Ocean

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 2.3.0 - Unreleased
 ==================
 
+- [fix] update bootstrapping for Digital Ocean to circumvent their latest attempts to lock out root
 
 
 2.2.0 - 2016-11-08

--- a/bsdploy/fabfile_digitalocean.py
+++ b/bsdploy/fabfile_digitalocean.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 from bsdploy.bootstrap_utils import BootstrapUtils
-from fabric.api import env, sudo, run
+from fabric.api import env, sudo, run, put
+from os import path
 from time import sleep
 
 # a plain, default fabfile for jailhosts on digital ocean
@@ -18,8 +19,22 @@ def bootstrap(**kwargs):
     # (temporarily) set the user to `freebsd`
     original_host = env.host_string
     env.host_string = 'freebsd@%s' % env.instance.uid
-    # copy DO bsdclout-init results:
-    sudo("""cat /etc/rc.digitalocean.d/droplet.conf > /etc/rc.conf""")
+    # overwrite sshd_config, because the DO version only contains defaults
+    # and a line explicitly forbidding root to log in
+    sudo("""echo 'PermitRootLogin without-password' > /etc/ssh/sshd_config""")
+    sudo("""echo 'Subsystem sftp /usr/libexec/sftp-server' >> /etc/ssh/sshd_config""")
+    sudo("""service sshd fastreload""")
+    # overwrite the authorized keys for root, because DO creates its entries to explicitly
+    # disallow root login
+    bootstrap_files = env.instance.config.get('bootstrap-files', 'bootstrap-files')
+    put(path.abspath(path.join(env['config_base'], bootstrap_files, 'authorized_keys')), '/tmp/authorized_keys', use_sudo=True)
+    sudo('''mv /tmp/authorized_keys /root/.ssh/''')
+    sudo('''chown root:wheel /root/.ssh/authorized_keys''')
+    # make sure root user is unlocked
+    sudo("""pw unlock root""", warn_only=True)
+    # copy DO bsdclout-init results, if present:
+    sudo("""cat /etc/rc.digitalocean.d/droplet.conf > /etc/rc.conf""", warn_only=True)
+    # enable basics
     sudo("""sysrc zfs_enable=YES""")
     sudo("""sysrc sshd_enable=YES""")
     # enable and start pf
@@ -30,19 +45,15 @@ def bootstrap(**kwargs):
     sudo('''echo 'pass out all' >> /etc/pf.conf''')
     sudo('''chmod 644 /etc/pf.conf''')
     sudo('service pf start')
-    # overwrite sshd_config, because the DO version only contains defaults
-    # and a line explicitly forbidding root to log in
-    sudo("""echo 'PermitRootLogin without-password' > /etc/ssh/sshd_config""")
-    sudo("""service sshd fastreload""")
     # revert back to root
     env.host_string = original_host
     # give sshd a chance to restart
     sleep(2)
     # clean up DO cloudinit leftovers
-    run("rm /etc/rc.d/digitalocean")
-    run("rm -r /etc/rc.digitalocean.d")
-    run("rm -r /usr/local/bsd-cloudinit/")
-    run("pkg remove -y avahi-autoipd")
+    run("rm /etc/rc.d/digitalocean", warn_only=True)
+    run("rm -r /etc/rc.digitalocean.d", warn_only=True)
+    run("rm -r /usr/local/bsd-cloudinit/", warn_only=True)
+    run("pkg remove -y avahi-autoipd", warn_only=True)
 
     # allow overwrites from the commandline
     env.instance.config.update(kwargs)


### PR DESCRIPTION
 to circumvent their latest attempts to lock out the root user root (they now inject they public keys for the given users with explicit instructions to disable logging in as root and lock the root user, too.

this patch fixes that in a probably backwards compatible manner