### PR TITLE
#102 explicitly reference the first interface

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,9 @@
 2.3.0 - Unreleased
 ==================
 
+- [fix] fix pf round-robin lockups. thanks to @igalic for reporting and fixing this issue
+
+
 
 
 2.2.0 - 2016-11-08

--- a/bsdploy/roles/jails_host/templates/pf.conf
+++ b/bsdploy/roles/jails_host/templates/pf.conf
@@ -1,5 +1,5 @@
 {% for network in pf_nat_jail_networks %}
-nat on {{ pf_nat_interface }} from {{ network }} to any -> ({{ pf_nat_interface }})
+nat on {{ pf_nat_interface }} from {{ network }} to any -> ({{ pf_nat_interface }}:0)
 {% endfor %}
 {% for rule in pf_nat_rules %}
 {{ rule }}


### PR DESCRIPTION
this avoids round-robin lookups which turn out to be quite cumbersome in the default setup.

thanks to @igalic for reporting and fixing this issue!